### PR TITLE
Add configuration for an app engine elastic runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/

--- a/gcp/app_engine/Dockerfile
+++ b/gcp/app_engine/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:18.04
+
+ENV RUNNER_VERSION=2.290.1
+ENV FLUTTER_SDK_VERSION=2.10.4
+
+RUN useradd -m actions
+RUN apt-get -yqq update && apt-get install -yqq curl jq wget git
+
+# Install Python3.8.
+RUN apt-get install -yqq python
+ENV PATH $PATH:/usr/local/bin/python
+RUN python --version
+
+# Install gcloud CLI.
+## Download the gcloud package.
+RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+
+## Install the package
+RUN mkdir -p /usr/local/gcloud \
+  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh --quiet
+
+## Add the package path to local.
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+
+# Install Dart, FVM & Flutter.
+RUN apt-get install -yqq apt-transport-https ca-certificates gnupg unzip
+RUN wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
+RUN apt-get -yqq update && apt-get install dart
+ENV PATH $PATH:$HOME/.pub-cache/bin
+RUN dart pub global activate fvm
+ENV PATH $PATH:$HOME/fvm/default/bin
+RUN $HOME/.pub-cache/bin/fvm install ${FLUTTER_SDK_VERSION}
+RUN $HOME/.pub-cache/bin/fvm global ${FLUTTER_SDK_VERSION}
+
+RUN \
+  LABEL="$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')" \
+  RUNNER_VERSION="$(echo ${latest_version_label:1})" \
+  cd /home/actions && mkdir actions-runner && cd actions-runner \
+  && wget https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
+  && tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+
+WORKDIR /home/actions/actions-runner
+RUN chown -R actions ~actions && /home/actions/actions-runner/bin/installdependencies.sh
+
+USER actions
+COPY entrypoint.sh .
+COPY runsvc.sh .
+ENTRYPOINT ["./entrypoint.sh"]

--- a/gcp/app_engine/README.md
+++ b/gcp/app_engine/README.md
@@ -1,0 +1,17 @@
+## Deploy the app engine runner
+
+### Install gcloud CLI
+
+https://cloud.google.com/sdk/docs/install
+
+### Navigate to the app engine runner directory
+
+```
+cd pipelines_runners/gcp_app_engine
+```
+
+### Deploy
+
+```
+gcloud app deploy --quiet --project spreeloop-ci-runners
+```

--- a/gcp/app_engine/app.yaml
+++ b/gcp/app_engine/app.yaml
@@ -1,0 +1,12 @@
+---
+service: default
+runtime: custom
+env: flex
+resources:
+  cpu: 2
+  memory_gb: 4
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 10
+  cpu_utilization:
+    target_utilization: 0.8

--- a/gcp/app_engine/entrypoint.sh
+++ b/gcp/app_engine/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+FLUTTER_SDK_VERSION="2.10.4"
+OWNER="spreeloop"
+REPO="place"
+NAME="gcp-app-engine-elastic"
+GITHUB_RUNNERS_TOKEN=$(gcloud secrets versions access latest --secret="GITHUB_RUNNERS_TOKEN")
+TOKEN=$(curl -s -X POST -H "authorization: token ${GITHUB_RUNNERS_TOKEN}" "https://api.github.com/repos/${OWNER}/${REPO}/actions/runners/registration-token" | jq -r .token)
+
+cleanup() {
+  ./config.sh remove --token "${TOKEN}"
+}
+
+./config.sh \
+  --url "https://github.com/${OWNER}/${REPO}" \
+  --token "${TOKEN}" \
+  --name "${NAME}" \
+  --unattended \
+  --work _work \
+  --labels python,flutter,flutter-${FLUTTER_SDK_VERSION},gcp,app-engine
+
+./runsvc.sh
+
+cleanup

--- a/gcp/app_engine/runsvc.sh
+++ b/gcp/app_engine/runsvc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# convert SIGTERM signal to SIGINT
+# for more info on how to propagate SIGTERM to a child process see: http://veithen.github.io/2014/11/16/sigterm-propagation.html
+trap 'kill -INT $PID' TERM INT
+
+if [ -f ".path" ]; then
+    # configure
+    export PATH=`cat .path`
+    echo ".path=${PATH}"
+fi
+
+nodever=${GITHUB_ACTIONS_RUNNER_FORCED_NODE_VERSION:-node16}
+
+# insert anything to setup env when running as a service
+# run the host process which keep the listener alive
+./externals/$nodever/bin/node ./bin/RunnerService.js &
+PID=$!
+wait $PID
+trap - TERM INT
+wait $PID


### PR DESCRIPTION
[pakona](https://github.com/pakona) commented [19 hours ago](https://github.com/spreeloop/place/pull/322#issue-1210313909)
Source: https://github.blog/2020-08-04-github-actions-self-hosted-runners-on-google-cloud/

The following config adds an app-engine Linux runner
that can help reduce our usage of Github build minutes.

The runner includes the following tools:
  - python
  - gcloud
  - flutter