### PR TITLE
Add config for compute engine runners

### DIFF
--- a/gcp/app_engine/entrypoint.sh
+++ b/gcp/app_engine/entrypoint.sh
@@ -2,7 +2,7 @@
 set -eEuo pipefail
 
 ORG="spreeloop"
-NAME="gcp-app-engine-elastic"
+NAME="gae-runner-elastic"
 GITHUB_RUNNERS_TOKEN=$(gcloud secrets versions access latest --secret="GITHUB_RUNNERS_TOKEN")
 
 TOKEN=$(curl -s -X POST -H "authorization: token ${GITHUB_RUNNERS_TOKEN}" "https://api.github.com/orgs/${ORG}/actions/runners/registration-token" | jq -r .token)
@@ -11,16 +11,13 @@ cleanup() {
   ./config.sh remove --token "${TOKEN}"
 }
 
-# Delete any runner with such name.
-curl -X DELETE -H "Accept: application/vnd.github.v3+json" -H "authorization: token ${GITHUB_RUNNERS_TOKEN}" https://api.github.com/orgs/${ORG}/actions/runners/${NAME}
-
 ./config.sh \
   --url "https://github.com/${ORG}" \
   --token "${TOKEN}" \
   --name "${NAME}" \
   --unattended \
   --work _work \
-  --labels gcp,app-engine
+  --labels gcp,app-engine,standard
 
 ./runsvc.sh
 

--- a/gcp/compute_engine/README.md
+++ b/gcp/compute_engine/README.md
@@ -1,0 +1,1 @@
+https://github.com/bharathkkb/gh-runners/tree/master/gce

--- a/gcp/compute_engine/create_instances.sh
+++ b/gcp/compute_engine/create_instances.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+gcloud compute instance-groups managed create runner-micro-group \
+    --project=spreeloop-ci-runners \
+    --size=2 \
+    --base-instance-name=gce-runner \
+    --template=gh-runner-micro-template \
+    --zone=us-central1-a

--- a/gcp/compute_engine/create_templates.sh
+++ b/gcp/compute_engine/create_templates.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+gcloud compute instance-templates create gh-runner-micro-template \
+    --project=spreeloop-ci-runners \
+    --image-family=ubuntu-1804-lts \
+    --image-project=ubuntu-os-cloud \
+    --boot-disk-type=pd-ssd \
+    --boot-disk-size=10GB \
+    --machine-type=e2-micro \
+    --scopes=cloud-platform \
+    --metadata-from-file=startup-script=startup.sh,shutdown-script=shutdown.sh

--- a/gcp/compute_engine/shutdown.sh
+++ b/gcp/compute_engine/shutdown.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get GITHUB_RUNNERS_TOKEN secret.
+GITHUB_RUNNERS_TOKEN=$(gcloud secrets versions access latest --secret="GITHUB_RUNNERS_TOKEN")
+
+# Stop and uninstall the runner service.
+cd /runner || exit
+./svc.sh stop
+./svc.sh uninstall
+
+# Remove the runner configuration.
+RUNNER_ALLOW_RUNASROOT=1 /runner/config.sh remove --unattended --token "$(curl -sS --request POST --url "https://api.github.com/orgs/spreeloop/actions/runners/remove-token" --header "authorization: Bearer ${GITHUB_RUNNERS_TOKEN}"  --header "content-type: application/json" | jq -r .token)"

--- a/gcp/compute_engine/startup.sh
+++ b/gcp/compute_engine/startup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eEuo pipefail
+
+# Install pre-requisites.
+apt-get update
+apt-get -yqq install \
+    jq \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+# Install Docker.
+# Source: https://docs.docker.com/engine/install/ubuntu/
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+apt-get -yqq install docker-ce
+
+# Setup runner for Github actions.
+ORG="spreeloop"
+NAME="${HOSTNAME}"
+GITHUB_RUNNERS_TOKEN=$(gcloud secrets versions access latest --secret="GITHUB_RUNNERS_TOKEN")
+TOKEN=$(curl -s -X POST -H "authorization: token ${GITHUB_RUNNERS_TOKEN}" "https://api.github.com/orgs/${ORG}/actions/runners/registration-token" | jq -r .token)
+
+## Download runner software.
+mkdir /runner-tmp
+mkdir /runner && cd /runner
+curl -o actions-runner-linux-x64-2.290.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.290.1/actions-runner-linux-x64-2.290.1.tar.gz
+echo "2b97bd3f4639a5df6223d7ce728a611a4cbddea9622c1837967c83c86ebb2baa  actions-runner-linux-x64-2.290.1.tar.gz" | shasum -a 256 -c
+tar xzf ./actions-runner-linux-x64-2.290.1.tar.gz
+
+RUNNER_ALLOW_RUNASROOT=1 /runner/config.sh \
+  --url "https://github.com/${ORG}" \
+  --token "${TOKEN}" \
+  --name "${NAME}" \
+  --unattended \
+  --replace \
+  --work "/runner-tmp" \
+  --labels gcp,compute-engine,micro
+
+## Install and start runner service.
+cd /runner || exit
+./svc.sh install
+./svc.sh start


### PR DESCRIPTION
Compute engines require more maintenance than app engines,
but they come at a lower price; which potentially also
allows us to run multiple instances at the same time.