### PR TITLE
Add config for compute engine runners

### DIFF
--- a/gcp/app_engine/Dockerfile
+++ b/gcp/app_engine/Dockerfile
@@ -4,7 +4,12 @@ ENV RUNNER_VERSION=2.290.1
 ENV FLUTTER_SDK_VERSION=2.10.4
 
 RUN useradd -m actions
-RUN apt-get -yqq update && apt-get install -yqq curl jq wget git
+RUN apt-get -yqq update && apt-get install -yqq curl jq wget
+
+# Install a recent version of Git.
+RUN add-apt-repository ppa:git-core/ppa -y
+RUN apt-get -yqq update && apt-get -yqq install git
+RUN git --version
 
 # Install Python3.8.
 RUN apt-get install -yqq python

--- a/gcp/compute_engine/create_instances.sh
+++ b/gcp/compute_engine/create_instances.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-gcloud compute instance-groups managed create runner-micro-group \
+gcloud compute instance-groups managed create runner-e2-medium-group \
     --project=spreeloop-ci-runners \
     --size=2 \
     --base-instance-name=gce-runner \
-    --template=gh-runner-micro-template \
+    --template=gh-runner-e2-medium-template \
     --zone=us-central1-a

--- a/gcp/compute_engine/create_templates.sh
+++ b/gcp/compute_engine/create_templates.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-gcloud compute instance-templates create gh-runner-micro-template \
+gcloud compute instance-templates create gh-runner-e2-medium-template \
     --project=spreeloop-ci-runners \
     --image-family=ubuntu-1804-lts \
     --image-project=ubuntu-os-cloud \
     --boot-disk-type=pd-ssd \
     --boot-disk-size=10GB \
-    --machine-type=e2-micro \
+    --machine-type=e2-medium \
     --scopes=cloud-platform \
     --metadata-from-file=startup-script=startup.sh,shutdown-script=shutdown.sh

--- a/gcp/compute_engine/startup.sh
+++ b/gcp/compute_engine/startup.sh
@@ -27,6 +27,11 @@ apt-get -yqq install \
     gnupg \
     lsb-release
 
+# Install a recent version of Git.
+add-apt-repository ppa:git-core/ppa -y
+apt-get -yqq update && apt-get -yqq install git
+git --version
+
 # Install Docker.
 # Source: https://docs.docker.com/engine/install/ubuntu/
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
@@ -56,7 +61,7 @@ RUNNER_ALLOW_RUNASROOT=1 /runner/config.sh \
   --unattended \
   --replace \
   --work "/runner-tmp" \
-  --labels gcp,compute-engine,micro
+  --labels gcp,compute-engine,e2-medium
 
 ## Install and start runner service.
 cd /runner || exit


### PR DESCRIPTION
Compute engines require more maintenance than app engines,
but they come at a lower price; which potentially also
allows us to run multiple instances at the same time.